### PR TITLE
Add ability to get version of DBMS from driver

### DIFF
--- a/driver/api/impl/impl.h
+++ b/driver/api/impl/impl.h
@@ -23,7 +23,7 @@ namespace impl {
         SQLHDBC connection_handle,
         SQLHDESC * out_descriptor_handle
     ) noexcept;
-    
+
     SQLRETURN freeHandle(
         SQLHANDLE handle
     ) noexcept;
@@ -203,5 +203,12 @@ namespace impl {
         SQLSMALLINT   FetchOrientation,
         SQLLEN        FetchOffset
     ) noexcept;
+
+    SQLRETURN getServerVersion(
+         SQLHDBC         conn,
+         SQLPOINTER      buffer_ptr,
+         SQLSMALLINT     buffer_len,
+         SQLSMALLINT *   string_length_ptr
+    );
 
 } // namespace impl

--- a/driver/api/odbc.cpp
+++ b/driver/api/odbc.cpp
@@ -127,6 +127,9 @@ SQLRETURN SQL_API EXPORTED_FUNCTION_MAYBE_W(SQLGetInfo)(
 
         switch (info_type) {
 
+            case SQL_DBMS_VER:
+                return impl::getServerVersion(connection_handle, out_value, out_value_max_length, out_value_length);
+
 #define CASE_STRING(NAME, VALUE) \
             case NAME:           \
                 return fillOutputString<SQLTCHAR>(VALUE, out_value, out_value_max_length, out_value_length, true);
@@ -136,7 +139,6 @@ SQLRETURN SQL_API EXPORTED_FUNCTION_MAYBE_W(SQLGetInfo)(
             CASE_STRING(SQL_DM_VER, "03.80.0000.0000")
             CASE_STRING(SQL_DRIVER_NAME, DRIVER_FILE_NAME)
             CASE_STRING(SQL_DBMS_NAME, "ClickHouse")
-            CASE_STRING(SQL_DBMS_VER, "01.00.0000")
             CASE_STRING(SQL_SERVER_NAME, connection.server)
             CASE_STRING(SQL_DATA_SOURCE_NAME, connection.dsn)
             CASE_STRING(SQL_CATALOG_TERM, "catalog")

--- a/driver/diagnostics.cpp
+++ b/driver/diagnostics.cpp
@@ -86,3 +86,13 @@ void DiagnosticsContainer::resetDiag() {
     header.setAttr(SQL_DIAG_NUMBER, 0);
     header.setAttr(SQL_DIAG_RETURNCODE, SQL_SUCCESS);
 }
+
+void copyDiagnosticsRecords(DiagnosticsContainer & from, DiagnosticsContainer & to)
+{
+    auto count = from.getDiagStatusCount();
+    for (size_t i = 1; i <= count; ++i)
+    {
+        auto record = from.getDiagStatus(i);
+        to.insertDiagStatus(std::move(record));
+    }
+}

--- a/driver/diagnostics.h
+++ b/driver/diagnostics.h
@@ -41,3 +41,9 @@ public:
 private:
     std::vector<DiagnosticsRecord> records;
 };
+
+// This function is useful when we want to propagate the diagnostics from
+// an ephemeral handle, for example a statement handle created for just one
+// query to another container, for example a connection handle or an environment
+// handle.
+void copyDiagnosticsRecords(DiagnosticsContainer & from, DiagnosticsContainer & to);

--- a/test/src/e2e/test_sanity.py
+++ b/test/src/e2e/test_sanity.py
@@ -3,6 +3,8 @@ from decimal import Decimal
 
 import pytest
 
+import pyodbc
+
 from util import pyodbc_connection, create_table
 
 TABLE_NAME = "test_sanity_simple_data_types"
@@ -97,3 +99,11 @@ class TestSanity:
                             [2, "test", datetime.date(2019, 5, 25)])
         assert len(result) == 1
         assert list(result[0]) == PYODBC_ROW2
+
+    def test_dbms_version(self, conn):
+        param_version = conn.connection.getinfo(pyodbc.SQL_DBMS_VER)
+
+        result = conn.query("SELECT version()")
+        query_version, = list(result[0])
+
+        assert param_version == query_version


### PR DESCRIPTION
The ODBC standard has a special way to get the version of the DBMS using `SQLGetInfo` with `SQL_DBMV_VER`. This change implements this option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved retrieval of the database version via ODBC, ensuring the version string matches the result of a direct SQL query.
- **Tests**
  - Added new tests to verify that the database version reported by the driver matches the version returned by a SQL query, both in integration and end-to-end scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->