### PR TITLE
Enable Python E2E tests for the Unicode Driver

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -191,11 +191,22 @@ jobs:
       run: |
         pip install -r requirements.txt
 
-      # An empty `ODBCSYSINI` is required in this case to run properly with custom `ODBCINI`/`ODBCINSTINI` paths
-    - name: Test - Run Python e2e tests
+    - name: Test - Run Python e2e tests for the ANSI driver
       working-directory: source/test
+      env:
+        DSN: "ClickHouse DSN (ANSI)"
+        ODBCSYSINI: ""  # Must be set for `ODBCINSTINI` and `ODBCINI` to work
+        ODBCINSTINI: ${{ github.workspace }}/run/.odbcinst.ini
+        ODBCINI: ${{ github.workspace }}/run/.odbc.ini
       run: |
-        export ODBCSYSINI=
-        export ODBCINSTINI="${{ github.workspace }}/run/.odbcinst.ini"
-        export ODBCINI="${{ github.workspace }}/run/.odbc.ini"
+        pytest --log-level=DEBUG -v
+
+    - name: Test - Run Python e2e tests for the Unicode driver
+      working-directory: source/test
+      env:
+        DSN: "ClickHouse DSN (Unicode)"
+        ODBCSYSINI: ""  # Must be set for `ODBCINSTINI` and `ODBCINI` to work
+        ODBCINSTINI: ${{ github.workspace }}/run/.odbcinst.ini
+        ODBCINI: ${{ github.workspace }}/run/.odbc.ini
+      run: |
         pytest --log-level=DEBUG -v

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -184,11 +184,9 @@ jobs:
       run: |
         ctest --output-on-failure --build-config ${{ matrix.build_type }} -E '.*-ut.*'
 
-    - name: Test - Run Python e2e tests for the ANSI driver
+    - name: Prepare Pythons dependencies
       if: ${{ matrix.architecture == 'x64' }}
       working-directory: source/test
-      env:
-        DSN: "ClickHouse DSN ANSI"
       run: |
         Write-Host "Check python version and architecture"
         python --version
@@ -197,7 +195,20 @@ jobs:
         Write-Host "Prepare Python dependencies"
         python -m pip install -r requirements.txt
 
-        Write-Host "Run tests"
+    - name: Test - Run Python e2e tests for the ANSI driver
+      if: ${{ matrix.architecture == 'x64' }}
+      working-directory: source/test
+      env:
+        DSN: "ClickHouse DSN ANSI"
+      run: |
+        python -m pytest --log-level=DEBUG -v
+
+    - name: Test - Run Python e2e tests for the Unicode driver
+      if: ${{ matrix.architecture == 'x64' }}
+      working-directory: source/test
+      env:
+        DSN: "ClickHouse DSN Unicode"
+      run: |
         python -m pytest --log-level=DEBUG -v
 
     - name: Upload artifacts as release assets


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Separated Python end-to-end tests for ANSI and Unicode drivers in both Linux and Windows workflows, improving test clarity and coverage.
  - Enhanced test utility to ensure temporary tables are created and cleaned up reliably across different environments, increasing compatibility and robustness.
  - Added Base64 encoding support in string data tests and refined enum test values for improved accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->