### PR TITLE
Enable Code Coverage on Linux

### DIFF
--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -1,0 +1,164 @@
+name: Code Coverage - Linux
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 1'
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ '**' ]
+  release:
+    types:
+      - created
+
+concurrency:
+  group: coverage-${{ github.head_ref }}
+  cancel-in-progress: true
+
+env:
+  LLVM_PROFILE_FILE: "profile_%p_%m.profraw"
+
+defaults:
+  run:
+    shell: bash
+    working-directory: run
+
+jobs:
+  build_and_test:
+
+    strategy:
+      fail-fast: false
+
+    runs-on: ubuntu-22.04
+
+    steps:
+
+    - name: Create directories
+      working-directory: ${{ github.workspace }}
+      run: |
+        mkdir -p ${{ github.workspace }}/run
+        mkdir -p ${{ github.workspace }}/build
+        mkdir -p ${{ github.workspace }}/prefix
+        mkdir -p ${{ github.workspace }}/install
+        mkdir -p ${{ github.workspace }}/package
+
+    - name: Clone the repo
+      uses: actions/checkout@v4
+      with:
+        path: source
+        submodules: true
+
+    - name: Install dependencies - Common
+      run: |
+        sudo apt update -q
+        sudo apt remove -y php* node* mysql* mssql-tools
+        sudo apt upgrade -y
+        sudo apt install -y build-essential git cmake docker perl libdbi-perl libdbd-odbc-perl python-is-python3 python3 python3-pip python3-setuptools libpoco-dev libssl-dev libicu-dev
+        sudo apt install -y unixodbc unixodbc-dev
+        sudo apt install -y clang llvm lldb
+        sudo apt autoremove -y
+
+    - name: Start ClickHouse in Docker
+      uses: hoverkraft-tech/compose-action@v2.0.1
+      with:
+        compose-file: source/test/docker-compose.yml
+        down-flags: --volumes
+
+    - name: Configure
+      run: >
+        CC=clang
+        CXX=clang++
+        cmake -S ${{ github.workspace }}/source -B ${{ github.workspace }}/build
+        -D CMAKE_POLICY_VERSION_MINIMUM=3.5
+        -D CMAKE_BUILD_TYPE=Debug
+        -D ODBC_PROVIDER=UnixODBC
+        -D TEST_DSN_LIST="ClickHouse DSN (ANSI);ClickHouse DSN (Unicode)"
+        -D CH_ODBC_ENABLE_CODE_COVERAGE=ON
+
+    - name: Build
+      run: cmake --build ${{ github.workspace }}/build --config Debug --parallel $(nproc)
+
+    - name: Prepare ODBC ini configs
+      run: |
+        echo "Preparing ODBC ini configs"
+        cat > ${{ github.workspace }}/run/.odbcinst.ini <<-EOF
+        [ODBC]
+        Trace     = 1
+        TraceFile = ${{ github.workspace }}/run/odbc-driver-manager-trace.log
+        Debug     = 1
+        DebugFile = ${{ github.workspace }}/run/odbc-driver-manager-debug.log
+
+        [ODBC Drivers]
+        ClickHouse ODBC Driver (ANSI)    = Installed
+        ClickHouse ODBC Driver (Unicode) = Installed
+
+        [ClickHouse ODBC Driver (ANSI)]
+        Driver     = ${{ github.workspace }}/build/driver/libclickhouseodbc.so
+        Setup      = ${{ github.workspace }}/build/driver/libclickhouseodbc.so
+        UsageCount = 1
+
+        [ClickHouse ODBC Driver (Unicode)]
+        Driver     = ${{ github.workspace }}/build/driver/libclickhouseodbcw.so
+        Setup      = ${{ github.workspace }}/build/driver/libclickhouseodbcw.so
+        UsageCount = 1
+        EOF
+
+        cat > ${{ github.workspace }}/run/.odbc.ini <<-EOF
+        [ODBC]
+        Trace     = 1
+        TraceFile = ${{ github.workspace }}/run/odbc-driver-manager-trace.log
+        Debug     = 1
+        DebugFile = ${{ github.workspace }}/run/odbc-driver-manager-debug.log
+
+        [ODBC Data Sources]
+        ClickHouse DSN (ANSI)         = ClickHouse ODBC Driver (ANSI)
+        ClickHouse DSN (Unicode)      = ClickHouse ODBC Driver (Unicode)
+
+        [ClickHouse DSN (ANSI)]
+        Driver        = ClickHouse ODBC Driver (ANSI)
+        Description   = Test DSN for ClickHouse ODBC Driver (ANSI)
+        Url           = http://${CLICKHOUSE_SERVER_IP}
+        DriverLog     = yes
+        DriverLogFile = ${{ github.workspace }}/run/clickhouse-odbc-driver.log
+
+        [ClickHouse DSN (Unicode)]
+        Driver        = ClickHouse ODBC Driver (Unicode)
+        Description   = Test DSN for ClickHouse ODBC Driver (Unicode)
+        Url           = http://localhost:8123
+        DriverLog     = yes
+        DriverLogFile = ${{ github.workspace }}/run/clickhouse-odbc-driver-w.log
+        EOF
+
+    - name: Test - Run C++ unit tests
+      working-directory: ${{ github.workspace }}/build
+      run: ctest --output-on-failure --build-config Debug -R '.*-ut.*'
+
+    - name: Test - Run C++ integration tests
+      working-directory: ${{ github.workspace }}/build
+      env:
+        DSN: "ClickHouse DSN (ANSI)"
+        ODBCSYSINI: ""  # Must be set for `ODBCINSTINI` and `ODBCINI` to work
+        ODBCINSTINI: ${{ github.workspace }}/run/.odbcinst.ini
+        ODBCINI: ${{ github.workspace }}/run/.odbc.ini
+      run: |
+        ctest --output-on-failure --build-config Debug -E '.*-ut.*'
+
+    - name: Collect Code Coverage
+      working-directory: ${{ github.workspace }}/build
+      run: |
+          ls
+          ls ./driver/test/
+          ls ./driver/test/*.profraw
+          llvm-profdata merge -sparse ./driver/test/*.profraw -o ./coverage.profdata
+          llvm-cov export ./driver/libclickhouseodbcw.so -instr-profile=./coverage.profdata -format=lcov > ${{ github.workspace }}/coverage.lcov
+          llvm-cov report ./driver/libclickhouseodbcw.so -format=text -instr-profile=./coverage.profdata
+
+    - name: Debug Coverage Data
+      run: |
+          ls -lh ${{ github.workspace }}/coverage.lcov
+
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -16,6 +16,9 @@ concurrency:
   group: linux-${{ github.head_ref }}
   cancel-in-progress: true
 
+env:
+  LLVM_PROFILE_FILE: "profile_%p_%m.profraw"
+
 defaults:
   run:
     shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ option (CH_ODBC_ALLOW_UNSAFE_DISPATCH "Allow unchecked handle dispatching (may s
 option (CH_ODBC_ENABLE_SSL "Enable SSL (required for utilizing https:// interface, etc.)" ON)
 option (CH_ODBC_ENABLE_INSTALL "Enable install targets (required for packaging)" ON)
 cmake_dependent_option (CH_ODBC_ENABLE_TESTING "Enable test targets" ON "BUILD_TESTING" OFF)
+option (CH_ODBC_ENABLE_CODE_COVERAGE "Enable Code Coverage" OFF)
 cmake_dependent_option (CH_ODBC_USE_ICU "Use ICU library, instead of C++ STD, for Unicode conversions" ON "NOT MSVC" OFF)
 option (CH_ODBC_PREFER_BUNDLED_THIRD_PARTIES "Prefer bundled over system variants of third party libraries" ON)
 cmake_dependent_option (CH_ODBC_PREFER_BUNDLED_POCO "Prefer bundled over system variants of Poco library" ON "CH_ODBC_PREFER_BUNDLED_THIRD_PARTIES" OFF)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+comment:                  #this is a top-level key
+  layout: " diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: false        # [true :: must have a base report to post]
+  require_head: true       # [true :: must have a head report to post]
+  hide_project_coverage: false # [true :: only show coverage on the git diff aka patch coverage]]

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -121,6 +121,11 @@ add_library (${libname}-impl STATIC
     statement.h
 )
 
+if (CH_ODBC_ENABLE_CODE_COVERAGE)
+    target_compile_options(${libname}-impl PRIVATE -fprofile-instr-generate -fcoverage-mapping)
+    target_link_options(${libname}-impl PRIVATE -fprofile-instr-generate -fcoverage-mapping)
+endif()
+
 set (WIN_SOURCES)
 if (WIN32)
     set (WIN_SOURCES
@@ -204,6 +209,11 @@ add_library (${libname} SHARED
     api/sql_columns_resultset_mutator.cpp
     ${WIN_SOURCES}
 )
+
+if (CH_ODBC_ENABLE_CODE_COVERAGE)
+    target_compile_options(${libname} PRIVATE -fprofile-instr-generate -fcoverage-mapping)
+    target_link_options(${libname} PRIVATE -fprofile-instr-generate -fcoverage-mapping)
+endif()
 
 target_link_libraries (${libname}
     PRIVATE ${libname}-impl

--- a/driver/test/CMakeLists.txt
+++ b/driver/test/CMakeLists.txt
@@ -21,6 +21,11 @@ function (declare_odbc_test_targets libname UNICODE)
         statement_parameter_binding_ut.cpp
     )
 
+    if (CH_ODBC_ENABLE_CODE_COVERAGE)
+        target_compile_options(${libname}-ut PRIVATE -fprofile-instr-generate -fcoverage-mapping)
+        target_link_options(${libname}-ut PRIVATE -fprofile-instr-generate -fcoverage-mapping)
+    endif()
+
     target_link_libraries (${libname}-ut
         PRIVATE ${libname}-impl
         PRIVATE gtest
@@ -83,6 +88,11 @@ function (declare_odbc_test_targets libname UNICODE)
         type_info_it.cpp
         authentication_it.cpp
     )
+
+    if (CH_ODBC_ENABLE_CODE_COVERAGE)
+        target_compile_options(${libname}-client-it PRIVATE -fprofile-instr-generate -fcoverage-mapping -fno-use-cxa-atexit)
+        target_link_options(${libname}-client-it PRIVATE -fprofile-instr-generate -fcoverage-mapping -fno-use-cxa-atexit)
+    endif()
 
     target_link_libraries (${libname}-client-it
         PRIVATE Poco::Foundation


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Integrated automated code coverage collection and reporting into the Linux build and test workflow.
  - Added support for generating and uploading code coverage reports to an external service.
  - Introduced a build option to enable or disable code coverage instrumentation for both the main driver and test binaries.

- **Chores**
  - Enhanced continuous integration workflow to include code coverage steps and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->